### PR TITLE
Fix console text not visible in dark mode (#5)

### DIFF
--- a/NppConsole/source/main.cxx
+++ b/NppConsole/source/main.cxx
@@ -298,7 +298,7 @@ void setInfo(NppData nppData)
 		}
 	}
 	IFV(!g_tbData.hClient);
-	g_tbData.uMask = DWS_DF_CONT_BOTTOM | DWS_ICONTAB;
+	g_tbData.uMask = DWS_DF_CONT_BOTTOM | DWS_ICONTAB | DWS_USEOWNDARKMODE;
 	::GetModuleFileName((HINSTANCE)g_hModule, modName, MAX_PATH);
 	g_tbData.pszModuleName = modName;
     g_tbData.dlgID = g_showWndInd;


### PR DESCRIPTION
### Cause
Foreground and background colors were identical in dark mode,
making console text invisible.

### Change
- Added the DWS_USEOWNDARKMODE flag to g_tbData.uMask
  to disable Notepad++ from forcing the foreground color to black
- Verified rendering on both light and dark mode

### Impact
Only affects console rendering. No functional side effects expected.

Closes #5