### PR TITLE
Add dark mode support to settings-dialog (#6)

### DIFF
--- a/NppConsole/source/main.cxx
+++ b/NppConsole/source/main.cxx
@@ -131,6 +131,12 @@ INT_PTR CALLBACK DialogProc(HWND hwndDlg, UINT uMsg,
             version += VER_STRING;
             version += "</a>";
             SetDlgItemTextA(hwndDlg, IDC_STC_VER, version.c_str());
+
+            // Add support for dark mode in the dialog.
+            ::SendMessage(g_nppData._nppHandle,
+                          NPPM_DARKMODESUBCLASSANDTHEME,
+                          static_cast<WPARAM>(NppDarkMode::dmfInit),
+                          reinterpret_cast<LPARAM>(hwndDlg));
 		}
 			return TRUE;
 


### PR DESCRIPTION
## Summary
This PR adds dark mode support to the settings dialog.

## Changes
- Send the `NPPM_DARKMODESUBCLASSANDTHEME` message in `WM_INITDIALOG`.
- Delegate the actual dark mode rendering to Notepad++.

## Known Limitation
- When "Follow Windows" is selected and Windows' dark mode is toggled
  while the dialog is open, button colors do not update.  
  - This seems to be a limitation or bug on the Notepad++ side.

Closes #6